### PR TITLE
native version for ha versions above 2025.6

### DIFF
--- a/custom_components/liquid-check/__init__.py
+++ b/custom_components/liquid-check/__init__.py
@@ -1,67 +1,44 @@
-""" Integration for Liquid-Check"""
-import voluptuous as vol
+from __future__ import annotations
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_MONITORED_CONDITIONS,
-)
-import homeassistant.helpers.config_validation as cv
-
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.core import HomeAssistant
-
-from .const import DOMAIN, SENSOR_TYPES, DATA_COORDINATOR
-from .coordinator import LiquidCheckDataUpdateCoordinator
-
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_HOST): cv.string,
-                vol.Required(CONF_MONITORED_CONDITIONS): vol.All(
-                    cv.ensure_list, [vol.In(list(SENSOR_TYPES))]
-                ),
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass, config):
-    """Platform setup, do nothing."""
-    hass.data.setdefault(DOMAIN, {})
-
-    if DOMAIN not in config:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=dict(config[DOMAIN])
-        )
-    )
-    return True
-
+from .api import LiquidCheckApi, LiquidCheckApiError
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS, SERVICE_START_MEASURE
+from .coordinator import LiquidCheckCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Load the saved entities."""
-    coordinator = LiquidCheckDataUpdateCoordinator(
-        hass,
-        config=entry.data,
-        options=entry.options,
-    )
+    session = async_get_clientsession(hass)
+    api = LiquidCheckApi(session, entry.data[CONF_HOST])
+    coordinator = LiquidCheckCoordinator(hass, api, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+    await coordinator.async_config_entry_first_refresh()
 
-    await coordinator.async_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    async def async_start_measure(call: ServiceCall) -> None:
+        entry_id = call.data.get("entry_id")
+        coordinators = hass.data.get(DOMAIN, {})
+        targets = [coordinators[entry_id]] if entry_id else list(coordinators.values())
+        for target in targets:
+            try:
+                await target.api.async_start_measure()
+                await target.async_request_refresh()
+            except LiquidCheckApiError as err:
+                raise HomeAssistantError(str(err)) from err
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_COORDINATOR: coordinator,
-    }
+    if not hass.services.has_service(DOMAIN, SERVICE_START_MEASURE):
+        hass.services.async_register(DOMAIN, SERVICE_START_MEASURE, async_start_measure)
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        if not hass.data.get(DOMAIN):
+            hass.services.async_remove(DOMAIN, SERVICE_START_MEASURE)
+    return unload_ok

--- a/custom_components/liquid-check/api.py
+++ b/custom_components/liquid-check/api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aiohttp import ClientError, ClientSession
+
+START_MEASURE_PAYLOAD: dict[str, Any] = {
+    "header": {
+        "namespace": "Device.Control",
+        "name": "StartMeasure",
+        "messageId": "1",
+        "payloadVersion": "1",
+    },
+    "payload": None,
+}
+
+class LiquidCheckApiError(Exception):
+    """Liquid-Check communication error."""
+
+class LiquidCheckApi:
+    def __init__(self, session: ClientSession, host: str) -> None:
+        host = host.strip().removeprefix("http://").removeprefix("https://").rstrip("/")
+        self.host = host
+        self._session = session
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}"
+
+    async def async_get_infos(self) -> dict[str, Any]:
+        try:
+            async with asyncio.timeout(10):
+                response = await self._session.get(f"{self.base_url}/infos.json")
+                response.raise_for_status()
+                data = await response.json(content_type=None)
+        except (TimeoutError, ClientError, ValueError) as err:
+            raise LiquidCheckApiError(str(err)) from err
+
+        if not isinstance(data, dict):
+            raise LiquidCheckApiError("Liquid-Check Antwort ist kein JSON-Objekt")
+
+        payload = data.get("payload", data)
+        if not isinstance(payload, dict):
+            raise LiquidCheckApiError("Liquid-Check Antwort enthält kein gültiges payload")
+        return payload
+
+    async def async_start_measure(self) -> None:
+        try:
+            async with asyncio.timeout(10):
+                response = await self._session.post(
+                    f"{self.base_url}/command",
+                    json=START_MEASURE_PAYLOAD,
+                    headers={"Content-Type": "application/json; charset=utf-8"},
+                )
+                response.raise_for_status()
+        except (TimeoutError, ClientError) as err:
+            raise LiquidCheckApiError(str(err)) from err

--- a/custom_components/liquid-check/api.py
+++ b/custom_components/liquid-check/api.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from aiohttp import ClientError, ClientSession
 
-
 START_MEASURE_PAYLOAD: dict[str, Any] = {
     "header": {
         "namespace": "Device.Control",
@@ -16,10 +15,8 @@ START_MEASURE_PAYLOAD: dict[str, Any] = {
     "payload": None,
 }
 
-
 class LiquidCheckApiError(Exception):
     """Liquid-Check communication error."""
-
 
 class LiquidCheckApi:
     def __init__(self, session: ClientSession, host: str) -> None:
@@ -41,13 +38,11 @@ class LiquidCheckApi:
             raise LiquidCheckApiError(str(err)) from err
 
         if not isinstance(data, dict):
-            raise LiquidCheckApiError("Liquid-Check response is not a JSON object")
+            raise LiquidCheckApiError("Liquid-Check Antwort ist kein JSON-Objekt")
 
         payload = data.get("payload", data)
-
         if not isinstance(payload, dict):
-            raise LiquidCheckApiError("Liquid-Check response does not contain a valid payload")
-
+            raise LiquidCheckApiError("Liquid-Check Antwort enthält kein gültiges payload")
         return payload
 
     async def async_start_measure(self) -> None:

--- a/custom_components/liquid-check/api.py
+++ b/custom_components/liquid-check/api.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from aiohttp import ClientError, ClientSession
 
+
 START_MEASURE_PAYLOAD: dict[str, Any] = {
     "header": {
         "namespace": "Device.Control",
@@ -15,8 +16,10 @@ START_MEASURE_PAYLOAD: dict[str, Any] = {
     "payload": None,
 }
 
+
 class LiquidCheckApiError(Exception):
     """Liquid-Check communication error."""
+
 
 class LiquidCheckApi:
     def __init__(self, session: ClientSession, host: str) -> None:
@@ -38,11 +41,13 @@ class LiquidCheckApi:
             raise LiquidCheckApiError(str(err)) from err
 
         if not isinstance(data, dict):
-            raise LiquidCheckApiError("Liquid-Check Antwort ist kein JSON-Objekt")
+            raise LiquidCheckApiError("Liquid-Check response is not a JSON object")
 
         payload = data.get("payload", data)
+
         if not isinstance(payload, dict):
-            raise LiquidCheckApiError("Liquid-Check Antwort enthält kein gültiges payload")
+            raise LiquidCheckApiError("Liquid-Check response does not contain a valid payload")
+
         return payload
 
     async def async_start_measure(self) -> None:

--- a/custom_components/liquid-check/config_flow.py
+++ b/custom_components/liquid-check/config_flow.py
@@ -38,7 +38,7 @@ class LiquidCheckConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_HOST, default="liquid-check.local"): str,
                 vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
             }
         )

--- a/custom_components/liquid-check/config_flow.py
+++ b/custom_components/liquid-check/config_flow.py
@@ -38,7 +38,7 @@ class LiquidCheckConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default="liquid-check"): str,
+                vol.Required(CONF_HOST): str,
                 vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
             }
         )

--- a/custom_components/liquid-check/config_flow.py
+++ b/custom_components/liquid-check/config_flow.py
@@ -38,7 +38,7 @@ class LiquidCheckConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_HOST, default="liquid.check"): str,
                 vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
             }
         )

--- a/custom_components/liquid-check/config_flow.py
+++ b/custom_components/liquid-check/config_flow.py
@@ -38,7 +38,7 @@ class LiquidCheckConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default="liquid.check"): str,
+                vol.Required(CONF_HOST, default="liquid-check"): str,
                 vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
             }
         )

--- a/custom_components/liquid-check/config_flow.py
+++ b/custom_components/liquid-check/config_flow.py
@@ -1,112 +1,45 @@
-"""Config flow for liquid-check integration."""
-# import logging
+from __future__ import annotations
+
+from typing import Any
 
 import voluptuous as vol
-import requests
-import json
-from requests.exceptions import HTTPError, ConnectTimeout
 
 from homeassistant import config_entries
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_MONITORED_CONDITIONS,
-)
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.util import slugify
-
-from .const import DOMAIN, SENSOR_TYPES  # pylint:disable=unused-import
-
-SUPPORTED_SENSOR_TYPES = list(SENSOR_TYPES)
-
-DEFAULT_MONITORED_CONDITIONS = [
-    "firmware",
-    "measure_percent",
-    "content_liters",
-]
-
-
-@callback
-def liquidcheck_entries(hass: HomeAssistant):
-    """Return the hosts for the domain."""
-    return set(
-        (entry.data[CONF_HOST]) for entry in hass.config_entries.async_entries(DOMAIN)
-    )
-
+from .api import LiquidCheckApi, LiquidCheckApiError
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 class LiquidCheckConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Liquid-Check config flow."""
-
     VERSION = 1
 
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
-
-    def __init__(self) -> None:
-        """Initialize the config flow."""
-        self._errors = {}
-        self._info = {}
-
-    def _host_in_configuration_exists(self, host) -> bool:
-        """Return True if site_id exists in configuration."""
-        if host in liquidcheck_entries(self.hass):
-            return True
-        return False
-
-    def _check_host(self, host) -> bool:
-        """Check if we can connect to the liquid-check."""
-        try:
-            response = requests.get(f"http://{host}/infos.json")
-            self._info = json.loads(response.text)
-        except (ConnectTimeout, HTTPError):
-            self._errors[CONF_HOST] = "could_not_connect"
-            return False
-
-        return True
-
-    async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
-
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
         if user_input is not None:
-            if self._host_in_configuration_exists(user_input[CONF_HOST]):
-                self._errors[CONF_HOST] = "host_exists"
+            host = user_input[CONF_HOST].strip().removeprefix("http://").removeprefix("https://").rstrip("/")
+            api = LiquidCheckApi(async_get_clientsession(self.hass), host)
+            try:
+                data = await api.async_get_infos()
+            except LiquidCheckApiError:
+                errors["base"] = "cannot_connect"
             else:
-                host = user_input[CONF_HOST]
-                conditions = user_input[CONF_MONITORED_CONDITIONS]
-                can_connect = await self.hass.async_add_executor_job(
-                    self._check_host, host
+                device = data.get("device", {}) if isinstance(data, dict) else {}
+                unique = str(device.get("uuid") or device.get("serial") or host)
+                await self.async_set_unique_id(unique)
+                self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+                return self.async_create_entry(
+                    title=device.get("name") or f"Liquid-Check {host}",
+                    data={
+                        CONF_HOST: host,
+                        CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    },
                 )
-                if can_connect:
-                    return self.async_create_entry(
-                        title=host,
-                        data={
-                            CONF_HOST: host,
-                            CONF_MONITORED_CONDITIONS: conditions,
-                        },
-                    )
-        else:
-            user_input = {}
-            user_input[CONF_HOST] = "liquid-check"
-            user_input[CONF_MONITORED_CONDITIONS] = DEFAULT_MONITORED_CONDITIONS
 
-        default_monitored_conditions = (
-            [] if self._async_current_entries() else DEFAULT_MONITORED_CONDITIONS
-        )
-        setup_schema = vol.Schema(
+        schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default=user_input[CONF_HOST]): str,
-                vol.Required(
-                    CONF_MONITORED_CONDITIONS, default=default_monitored_conditions
-                ): cv.multi_select(SUPPORTED_SENSOR_TYPES),
+                vol.Required(CONF_HOST): str,
+                vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
             }
         )
-
-        return self.async_show_form(
-            step_id="user", data_schema=setup_schema, errors=self._errors
-        )
-
-    async def async_step_import(self, user_input=None):
-        """Import a config entry."""
-        if self._host_in_configuration_exists(user_input[CONF_HOST]):
-            return self.async_abort(reason="host_exists")
-        return await self.async_step_user(user_input)
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/custom_components/liquid-check/const.py
+++ b/custom_components/liquid-check/const.py
@@ -1,24 +1,75 @@
-"""Constants for the liquid-check integration."""
-from datetime import timedelta
+from __future__ import annotations
 
-from homeassistant.const import (
-    UnitOfVolume,
-    UnitOfLength,
-    PERCENTAGE,
-)
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import PERCENTAGE, Platform
 
 DOMAIN = "liquid_check"
+PLATFORMS = [Platform.SENSOR]
 
-DATA_COORDINATOR = "corrdinator"
+DEFAULT_SCAN_INTERVAL = 30
+CONF_SCAN_INTERVAL = "scan_interval"
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+SERVICE_START_MEASURE = "start_measure"
 
-SENSOR_TYPES = {
-    "device": ["Device", None, "", "data", "device/name"],
-    "firmware": ["Firmware Version", None, "", "data", "device/firmware"],
-    "measure_percent": ["Füllstand", PERCENTAGE, "", "data", "measure/percent"],
-    "level": ["Pegelstand", UnitOfLength.METERS, "", "data", "measure/level"],
-    "content_liters": ["Inhalt", UnitOfVolume.LITERS, "", "data", "measure/content"],
-    "age": ["Alter", None, "", "data", "measure/age"],
-    "error": ["Fehler", None, "", "data", "system/error"],
-}
+@dataclass(frozen=True)
+class LiquidCheckSensorDef:
+    key: str
+    name: str
+    path: tuple[str, ...]
+    native_unit_of_measurement: str | None = None
+    device_class: SensorDeviceClass | str | None = None
+    state_class: SensorStateClass | str | None = None
+    icon: str | None = None
+
+SENSORS: tuple[LiquidCheckSensorDef, ...] = (
+    LiquidCheckSensorDef(
+        key="measure_percent",
+        name="Füllstand",
+        path=("measure", "percent"),
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gauge",
+    ),
+    LiquidCheckSensorDef(
+        key="content_liters",
+        name="Inhalt",
+        path=("measure", "content"),
+        native_unit_of_measurement="L",
+        device_class=SensorDeviceClass.VOLUME,
+        state_class=None,
+        icon="mdi:water",
+    ),
+    LiquidCheckSensorDef(
+        key="level",
+        name="Pegelstand",
+        path=("measure", "level"),
+        native_unit_of_measurement="m",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:waves",
+    ),
+    LiquidCheckSensorDef(
+        key="age",
+        name="Messwertalter",
+        path=("measure", "age"),
+        native_unit_of_measurement="s",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:timer-outline",
+    ),
+    LiquidCheckSensorDef(
+        key="error",
+        name="Fehler",
+        path=("system", "error"),
+        icon="mdi:alert-circle-outline",
+    ),
+    LiquidCheckSensorDef(
+        key="firmware",
+        name="Firmware",
+        path=("device", "firmware"),
+        icon="mdi:chip",
+    ),
+)

--- a/custom_components/liquid-check/const.py
+++ b/custom_components/liquid-check/const.py
@@ -39,7 +39,7 @@ SENSORS: tuple[LiquidCheckSensorDef, ...] = (
         path=("measure", "content"),
         native_unit_of_measurement="L",
         device_class=SensorDeviceClass.VOLUME,
-        state_class=None,
+        state_class=SensorStateClass.TOTAL,
         icon="mdi:water",
     ),
     LiquidCheckSensorDef(

--- a/custom_components/liquid-check/coordinator.py
+++ b/custom_components/liquid-check/coordinator.py
@@ -1,59 +1,36 @@
-"""Provides the Liquid-Check DataUpdateCoordinator."""
-from datetime import timedelta
-import logging
-import requests
-import json
+from __future__ import annotations
 
-from async_timeout import timeout
-from homeassistant.util.dt import utcnow
-from homeassistant.const import CONF_HOST
+from datetime import timedelta
+from typing import Any
+import logging
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .api import LiquidCheckApi, LiquidCheckApiError
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-
-class LiquidCheckDataUpdateCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching Liquid-Check data."""
-
-    def __init__(self, hass: HomeAssistant, *, config: dict, options: dict):
-        """Initialize global liquitd-check data updater."""
-        self._host = config[CONF_HOST]
-        self._next_update = 0
-        update_interval = timedelta(seconds=30)
-
+class LiquidCheckCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api: LiquidCheckApi,
+        scan_interval: int = DEFAULT_SCAN_INTERVAL,
+    ) -> None:
         super().__init__(
             hass,
-            _LOGGER,
+            logger=_LOGGER,
             name=DOMAIN,
-            update_interval=update_interval,
+            update_interval=timedelta(seconds=max(10, int(scan_interval))),
         )
+        self.api = api
 
-    async def _async_update_data(self) -> dict:
-        """Fetch data from LiquidCheck."""
-
-        def _update_data() -> dict:
-            """Fetch data from Liquid-Check via sync functions."""
-            data = self.data_update()
-
-            return {
-                "data": data["payload"]
-            }
-
+    async def _async_update_data(self) -> dict[str, Any]:
         try:
-            async with timeout(4):
-                return await self.hass.async_add_executor_job(_update_data)
-        except Exception as error:
-            raise UpdateFailed(f"Invalid response from API: {error}") from error
+            data = await self.api.async_get_infos()
+        except LiquidCheckApiError as err:
+            raise UpdateFailed(str(err)) from err
 
-    def data_update(self):
-        """Update liquid check data."""
-        try:
-            response = requests.get(f"http://{self._host}/infos.json")
-            data = json.loads(response.text)
-            _LOGGER.debug(data)
-            return data
-        except:
-            pass
+        return data

--- a/custom_components/liquid-check/manifest.json
+++ b/custom_components/liquid-check/manifest.json
@@ -13,6 +13,6 @@
     "issue_tracker": "https://github.com/shivan/homeassistant-liquidcheck/issues",
     "requirements":
     [],
-    "version": "2.0.10",
+    "version": "2.0.11",
     "homeassistant": "2025.6.0"
 }

--- a/custom_components/liquid-check/manifest.json
+++ b/custom_components/liquid-check/manifest.json
@@ -13,5 +13,6 @@
     "issue_tracker": "https://github.com/shivan/homeassistant-liquidcheck/issues",
     "requirements":
     [],
-    "version": "1.0.4"
+    "version": "2.0.10",
+    "homeassistant": "2025.6.0"
 }

--- a/custom_components/liquid-check/sensor.py
+++ b/custom_components/liquid-check/sensor.py
@@ -1,101 +1,75 @@
-"""The liquid-check integration."""
+from __future__ import annotations
 
-import logging
-from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_HOST
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import SENSOR_TYPES, DOMAIN, DATA_COORDINATOR
-from .coordinator import LiquidCheckDataUpdateCoordinator
+from .const import DOMAIN, SENSORS, LiquidCheckSensorDef
+from .coordinator import LiquidCheckCoordinator
 
-_LOGGER = logging.getLogger(__name__)
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: LiquidCheckCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [LiquidCheckSensor(coordinator, entry, sensor_def) for sensor_def in SENSORS]
+    )
 
+def _get_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
+    value: Any = data
+    for part in path:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
 
-async def async_setup_entry(hass, entry, async_add_entities):
-    """Add an Liquid-Check entry."""
-    coordinator: LiquidCheckDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        DATA_COORDINATOR
-    ]
+class LiquidCheckSensor(CoordinatorEntity[LiquidCheckCoordinator], SensorEntity):
+    _attr_has_entity_name = True
 
-    entities = []
-
-    host = entry.data[CONF_HOST]
-
-    for sensor in entry.data[CONF_MONITORED_CONDITIONS]:
-        entities.append(LiquidCheckDevice(coordinator, sensor, entry.title, host))
-    async_add_entities(entities)
-
-
-class LiquidCheckDevice(CoordinatorEntity):
-    """Representation of a Liquid-Check device."""
-
-    def __init__(self, coordinator, sensor_type, name, host):
-        """Initialize the sensor."""
+    def __init__(
+        self,
+        coordinator: LiquidCheckCoordinator,
+        entry: ConfigEntry,
+        sensor_def: LiquidCheckSensorDef,
+    ) -> None:
         super().__init__(coordinator)
-        self._sensor = SENSOR_TYPES[sensor_type][0]
-        self._name = name
-        self.type = sensor_type
-        self._data_source = SENSOR_TYPES[sensor_type][3]
-        # json path for data
-        self._data_path = SENSOR_TYPES[sensor_type][4]
-        self.coordinator = coordinator
-        self._last_value = None
-        self._unit_of_measurement = SENSOR_TYPES[self.type][1]
-        self._icon = SENSOR_TYPES[self.type][2]
-        self.serial_number = self.coordinator.data[self._data_source]["device"]["uuid"] + host
-        self.model = self.coordinator.data[self._data_source]["device"]["name"]
-        self._host = host
-        self._attr_unique_id = f"{host}_{sensor_type}"
-        self._attr_name = f"LiquidCheck {host} {sensor_type}"
-        _LOGGER.debug(self.coordinator)
+        self._entry = entry
+        self._sensor_def = sensor_def
+        host = entry.data[CONF_HOST]
 
-    def getDataByPath(self, dataObject, jsonPath):
-        keys = jsonPath.split('/')
-        value = dataObject
-        for key in keys:
-            value = value.get(key)
-            if value is None:
-                return None  # Schlüssel nicht gefunden, gib None zurück
-        return value
+        # No custom EntityDescription object. This avoids the HA 2026
+        # entity_description compatibility problem from the old integration.
+        self._attr_name = sensor_def.name
+        self._attr_unique_id = f"{entry.unique_id or host}_{sensor_def.key}"
+        self._attr_native_unit_of_measurement = sensor_def.native_unit_of_measurement
+        self._attr_device_class = sensor_def.device_class
+        self._attr_state_class = sensor_def.state_class
+        self._attr_icon = sensor_def.icon
 
     @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"{self._name} {self._sensor}"
+    def native_value(self) -> Any:
+        return _get_path(self.coordinator.data or {}, self._sensor_def.path)
 
     @property
-    def state(self):
-        """Return the state of the device."""
-        try:
-            state = self.getDataByPath(self.coordinator.data[self._data_source], self._data_path)
-            
-            self._last_value = state
-        except Exception as ex:
-            _LOGGER.error(ex)
-            state = self._last_value
+    def device_info(self) -> DeviceInfo:
+        data = self.coordinator.data or {}
+        device = data.get("device", {}) if isinstance(data, dict) else {}
+        host = self._entry.data[CONF_HOST]
+        serial = str(device.get("uuid") or device.get("serial") or host)
 
-        return state
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement this sensor expresses itself in."""
-        return self._unit_of_measurement
-
-    @property
-    def icon(self):
-        """Return icon."""
-        return self._icon
-
-    @property
-    def unique_id(self):
-        """Return unique id based on device serial and variable."""
-        return "{} {}".format(self.serial_number, self._sensor)
-
-    @property
-    def device_info(self):
-        """Return information about the device."""
-        return {
-            "identifiers": {(DOMAIN, self.serial_number)},
-            "name": self._name,
-            "manufacturer": "SI-Elektronik GmbH",
-            "model": self.model,
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=device.get("name") or self._entry.title,
+            manufacturer="SI-Elektronik GmbH",
+            model="Liquid-Check",
+            sw_version=device.get("firmware"),
+            configuration_url=f"http://{host}",
+        )

--- a/custom_components/liquid-check/sensor.py
+++ b/custom_components/liquid-check/sensor.py
@@ -11,6 +11,19 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, SENSORS, LiquidCheckSensorDef
+
+# Entity unique_ids and device identifiers must stay compatible with the
+# original shivan/homeassistant-liquidcheck integration. Otherwise Home
+# Assistant treats the same physical Liquid-Check as a new device after the
+# native rewrite and creates duplicate devices/entities.
+LEGACY_SENSOR_NAMES: dict[str, str] = {
+    "firmware": "Firmware Version",
+    "measure_percent": "Füllstand",
+    "content_liters": "Inhalt",
+    "level": "Pegelstand",
+    "age": "Alter",
+    "error": "Fehler",
+}
 from .coordinator import LiquidCheckCoordinator
 
 async def async_setup_entry(
@@ -48,11 +61,20 @@ class LiquidCheckSensor(CoordinatorEntity[LiquidCheckCoordinator], SensorEntity)
         # No custom EntityDescription object. This avoids the HA 2026
         # entity_description compatibility problem from the old integration.
         self._attr_name = sensor_def.name
-        self._attr_unique_id = f"{entry.unique_id or host}_{sensor_def.key}"
+        self._legacy_serial = self._get_legacy_serial(host)
+        legacy_sensor_name = LEGACY_SENSOR_NAMES.get(sensor_def.key, sensor_def.name)
+        self._attr_unique_id = f"{self._legacy_serial} {legacy_sensor_name}"
         self._attr_native_unit_of_measurement = sensor_def.native_unit_of_measurement
         self._attr_device_class = sensor_def.device_class
         self._attr_state_class = sensor_def.state_class
         self._attr_icon = sensor_def.icon
+
+    def _get_legacy_serial(self, host: str) -> str:
+        data = self.coordinator.data or {}
+        device = data.get("device", {}) if isinstance(data, dict) else {}
+        # Old integration used uuid + host as both the device identifier basis
+        # and the entity unique_id prefix. Preserve that exact shape.
+        return f"{device.get('uuid') or device.get('serial') or host}{host}"
 
     @property
     def native_value(self) -> Any:
@@ -63,7 +85,7 @@ class LiquidCheckSensor(CoordinatorEntity[LiquidCheckCoordinator], SensorEntity)
         data = self.coordinator.data or {}
         device = data.get("device", {}) if isinstance(data, dict) else {}
         host = self._entry.data[CONF_HOST]
-        serial = str(device.get("uuid") or device.get("serial") or host)
+        serial = self._get_legacy_serial(host)
 
         return DeviceInfo(
             identifiers={(DOMAIN, serial)},

--- a/custom_components/liquid-check/services.yaml
+++ b/custom_components/liquid-check/services.yaml
@@ -1,0 +1,11 @@
+start_measure:
+  name: Messung starten
+  description: Startet eine neue Liquid-Check-Messung. Ohne entry_id werden alle Liquid-Check-Geräte ausgelöst.
+  fields:
+    entry_id:
+      name: Config Entry ID
+      description: Optional. Nur dieses Liquid-Check-Gerät auslösen.
+      example: "01J..."
+      required: false
+      selector:
+        text:

--- a/custom_components/liquid-check/strings.json
+++ b/custom_components/liquid-check/strings.json
@@ -1,20 +1,20 @@
 {
-  "title": "Liquid-Check",
   "config": {
     "step": {
       "user": {
+        "title": "Set up Liquid-Check",
+        "description": "Enter the IP address or hostname of the Liquid-Check device.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "Host/IP",
+          "scan_interval": "Polling interval in seconds"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "cannot_connect": "Connection failed. Check the IP address and ensure that /infos.json is reachable."
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "This Liquid-Check device is already configured."
     }
   }
 }

--- a/custom_components/liquid-check/translations/de.json
+++ b/custom_components/liquid-check/translations/de.json
@@ -1,18 +1,20 @@
 {
-  "title": "Liquid-Check",
-  "config": {    
+  "config": {
     "step": {
       "user": {
+        "title": "Liquid-Check einrichten",
+        "description": "IP-Adresse oder Hostnamen des Liquid-Check eingeben.",
         "data": {
-          "host": "Die IP-Adresse des Liquid-Check-Geräts"
+          "host": "Host/IP",
+          "scan_interval": "Abfrageintervall in Sekunden"
         }
       }
     },
     "error": {
-      "host_exists": "Dieses Ger\u00e4t wurde bereits konfiguriert."
+      "cannot_connect": "Verbindung fehlgeschlagen. Prüfe IP-Adresse und ob /infos.json erreichbar ist."
     },
     "abort": {
-      "host_exists": "Dieses Ger\u00e4t wurde bereits konfiguriert."
+      "already_configured": "Dieses Liquid-Check-Gerät ist bereits eingerichtet."
     }
   }
 }

--- a/custom_components/liquid-check/translations/en.json
+++ b/custom_components/liquid-check/translations/en.json
@@ -1,18 +1,20 @@
 {
-  "title": "Liquid-Check",
-  "config": {    
+  "config": {
     "step": {
       "user": {
+        "title": "Set up Liquid-Check",
+        "description": "Enter the IP address or hostname of the Liquid-Check device.",
         "data": {
-          "host": "The ip address of the liquid-check device"
+          "host": "Host/IP",
+          "scan_interval": "Polling interval in seconds"
         }
       }
     },
     "error": {
-      "host_exists": "This host is already configured"
+      "cannot_connect": "Connection failed. Check the IP address and whether /infos.json is reachable."
     },
     "abort": {
-      "host_exists": "This host is already configured"
+      "already_configured": "This Liquid-Check device is already configured."
     }
   }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,9 @@
   "name": "Liquid-Check",
   "content_in_root": false,
   "render_readme": true,
-  "country": "DE",
-  "homeassistant": "2023.8"
+  "domains": [
+    "sensor"
+  ],
+  "homeassistant": "2025.6.0",
+  "hacs": "2.0.0"
 }


### PR DESCRIPTION
rewritten for newer ha versions

please test, change, improve  and release as beta version if it is good

- Added compatibility with current Home Assistant versions (2025/2026)
- Removed deprecated EntityDescription implementation
- Modernized config flow
- Improved support for multiple Liquid-Check devices
- Fixed Home Assistant sensor class warnings
- Improved /infos.json error handling
- Added compatibility with current Python and Home Assistant APIs
- Modernized liquid_check.start_measure service
- Various stability and compatibility fixes