### PR TITLE
Fix state_class for volume sensor (TOTAL -> MEASUREMENT)

### DIFF
--- a/custom_components/liquid_check/const.py
+++ b/custom_components/liquid_check/const.py
@@ -39,7 +39,7 @@ SENSORS: tuple[LiquidCheckSensorDef, ...] = (
         path=("measure", "content"),
         native_unit_of_measurement="L",
         device_class=SensorDeviceClass.VOLUME,
-        state_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:water",
     ),
     LiquidCheckSensorDef(


### PR DESCRIPTION
MEASUREMENT tracks the actual water level (min/max), while TOTAL incorrectly sums up every fluctuation.