### PR TITLE
Fixes back to device class None

### DIFF
--- a/custom_components/liquid_check/const.py
+++ b/custom_components/liquid_check/const.py
@@ -39,7 +39,7 @@ SENSORS: tuple[LiquidCheckSensorDef, ...] = (
         path=("measure", "content"),
         native_unit_of_measurement="L",
         device_class=SensorDeviceClass.VOLUME,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=None,
         icon="mdi:water",
     ),
     LiquidCheckSensorDef(


### PR DESCRIPTION
Sorry need to revert back. I got the error:

Entity sensor..inhalt (<class 'custom_components.liquid_check.sensor.LiquidCheckSensor'>) is using state class 'measurement' which is impossible considering device class ('volume') it is using; expected None or one of 'total_increasing', 'total'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/shivan/homeassistant-liquidcheck/issues